### PR TITLE
Allow direct uploads to AWS S3 from the browser

### DIFF
--- a/request_forwarder.go
+++ b/request_forwarder.go
@@ -61,6 +61,7 @@ func forward(req *Request, backend Backend) {
 
 	copyResponseHeaders(res, req)
 	req.ResponseWriter.WriteHeader(res.StatusCode)
+	req.ResponseWriter.Header().Add("Access-Control-Allow-Origin", "*")
 
 	io.Copy(req.ResponseWriter, res.Body)
 


### PR DESCRIPTION
### Description
The front-ends need to upload directly to S3 via a pre-signed URL and this PR enable this feature

The steps to get of the AWS Credential is
1. Try to get the "Authorization" header
2. Try to get the "X-Amz-Credential" query string

I directly added the "Access-Control-Allow-Origin" header with the value "*" but I accept suggestions. :-/